### PR TITLE
Replace openseespyvis with vfo

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,7 @@ setuptools
 scipy
 xarray
 opsvis
-openseespyvis
+vfo
 pydata-sphinx-theme
 recommonmark
 Sphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires-python = ">=3.8"
 dependencies = [
     "openseespy>=3.2.2.6",
     "opsvis~=0.95.5",
-    "openseespyvis>=0.0.6",
+    "vfo>=0.0.6",
     "matplotlib",
     "numpy",
     "pandas",

--- a/src/ospgrillage/postprocessing.py
+++ b/src/ospgrillage/postprocessing.py
@@ -17,7 +17,7 @@ from scipy.interpolate import interpn, RegularGridInterpolator
 from ospgrillage.load import ShapeFunction
 from ospgrillage.static import solve_zeta_eta
 
-import openseespyvis.Get_Rendering as opsplt
+import vfo.vfo as opsplt
 
 
 def create_envelope(**kwargs):


### PR DESCRIPTION
+ The openseespyvis package is no longer available on PyPi, so ospgrillage cannot be installed using pip as this dependency cannot be resolved.
+ To fix this, openseespyvis has been replaced by vfo (https://pypi.org/project/vfo/) which appears to be an API compatible continuation of the functionality of opensesspyvis.
+ To minimise changes to the codebase, the vfo module is still imported as og.opsplt.