### PR TITLE
fix: remove openseespyvis from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "openseespy>=3.2.2.6",
     "opsvis~=0.95.5",
     "vfo>=0.0.6",
     "matplotlib",


### PR DESCRIPTION
PR to resolve issue with installations. This fix removes openseespyvis module from its dependencies

Log of installation error

```
Collecting ospgrillage
  Obtaining dependency information for ospgrillage from https://files.pythonhosted.org/packages/51/7c/12718714a118b8e6ae5fc784c869aa96fa21cc1357c282163accf0ad755d/ospgrillage-0.3.1-py2.py3-none-any.whl.metadata
  Using cached ospgrillage-0.3.1-py2.py3-none-any.whl.metadata (7.0 kB)
Collecting openseespy>=3.2.2.6 (from ospgrillage)
  Obtaining dependency information for openseespy>=3.2.2.6 from https://files.pythonhosted.org/packages/21/5f/f18204abfd86bab27afe9a6cce547d2bc2f9730b76dd8edfd2e3c8fe7ecc/openseespy-3.7.1.2-py3-none-any.whl.metadata
  Using cached openseespy-3.7.1.2-py3-none-any.whl.metadata (2.3 kB)
Collecting opsvis~=0.95.5 (from ospgrillage)
  Obtaining dependency information for opsvis~=0.95.5 from https://files.pythonhosted.org/packages/88/ed/bdebadec2e9c764f64dadd7a2cf55dda42ba9a644f35685c2cfba9991cf7/opsvis-0.95.9-py3-none-any.whl.metadata
  Using cached opsvis-0.95.9-py3-none-any.whl.metadata (1.0 kB)
INFO: pip is looking at multiple versions of ospgrillage to determine which version is compatible with other requirements. This could take a while.
Collecting ospgrillage
  Obtaining dependency information for ospgrillage from https://files.pythonhosted.org/packages/de/45/b1aaf84928ed809ad4da1013ec431244418bcfcff8935f2ed15fb0892ff5/ospgrillage-0.2.1-py2.py3-none-any.whl.metadata
  Using cached ospgrillage-0.2.1-py2.py3-none-any.whl.metadata (6.8 kB)
  Obtaining dependency information for ospgrillage from https://files.pythonhosted.org/packages/83/b4/d1476393456bbe1764100a8d61e001ac2b26f9478304e5fbb198867eb578/ospgrillage-0.2.0-py2.py3-none-any.whl.metadata
  Using cached ospgrillage-0.2.0-py2.py3-none-any.whl.metadata (6.4 kB)
  Obtaining dependency information for ospgrillage from https://files.pythonhosted.org/packages/de/1f/6e8823324bf59da98a4408b7fea963ad0d0e8d9302d48ab6833b22172a1b/ospgrillage-0.1.1-py2.py3-none-any.whl.metadata
  Using cached ospgrillage-0.1.1-py2.py3-none-any.whl.metadata (6.1 kB)
  Obtaining dependency information for ospgrillage from https://files.pythonhosted.org/packages/7a/14/c9ca6125977df18455c668d47aedda37dcb064461dc592a9c99c72c0728e/ospgrillage-0.1.0-py2.py3-none-any.whl.metadata
  Using cached ospgrillage-0.1.0-py2.py3-none-any.whl.metadata (6.1 kB)
  Obtaining dependency information for ospgrillage from https://files.pythonhosted.org/packages/8d/2d/18becc7661813f5cea1c6d303537e21b6059847fd1d758ce826c59661be9/ospgrillage-0.0.2-py2.py3-none-any.whl.metadata
  Using cached ospgrillage-0.0.2-py2.py3-none-any.whl.metadata (6.2 kB)

The conflict is caused by:
    ospgrillage 0.3.1 depends on openseespyvis>=0.0.6
    ospgrillage 0.2.1 depends on openseespyvis>=0.0.6
    ospgrillage 0.2.0 depends on openseespyvis>=0.0.6
    ospgrillage 0.1.1 depends on openseespyvis>=0.0.6
    ospgrillage 0.1.0 depends on openseespyvis>=0.0.6
    ospgrillage 0.0.2 depends on openseespyvis>=0.0.6

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict


ERROR: Cannot install ospgrillage==0.0.2, ospgrillage==0.1.0, ospgrillage==0.1.1, ospgrillage==0.2.0, ospgrillage==0.2.1 and ospgrillage==0.3.1 because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts

[notice] A new release of pip is available: 23.2.1 -> 25.0.1
[notice] To update, run: python.exe -m pip install --upgrade pip